### PR TITLE
Update instrument.rb

### DIFF
--- a/lib/graphql/preload/instrument.rb
+++ b/lib/graphql/preload/instrument.rb
@@ -20,6 +20,7 @@ module GraphQL
       end
 
       private def preload(record, associations)
+        raise TypeError, "Expected #{associations} to be a Symbol, not a String" if associations.is_a?(String)
         return preload_single_association(record, associations) if associations.is_a?(Symbol)
 
         promises = []


### PR DESCRIPTION
I was using this gem with dynamically created Types. I was accidentally passing in Strings for some of the associations, which wouldn't complain, but also wouldn't do anything. This pull requests adds a complaint if Strings are passed accidentally.