### PR TITLE
Add the ability to preload with a scope

### DIFF
--- a/lib/graphql/preload.rb
+++ b/lib/graphql/preload.rb
@@ -6,7 +6,8 @@ GraphQL::Field.accepts_definitions(
   preload: ->(type, *args) do
     type.metadata[:preload] ||= []
     type.metadata[:preload].concat(args)
-  end
+  end,
+  preload_scope: ->(type, arg) { type.metadata[:preload_scope] = arg }
 )
 
 GraphQL::Schema.accepts_definitions(

--- a/lib/graphql/preload/instrument.rb
+++ b/lib/graphql/preload/instrument.rb
@@ -10,11 +10,10 @@ module GraphQL
           return old_resolver.call(obj, args, ctx) unless obj
 
           if field.metadata[:preload_scope]
-            scope_lambda = field.metadata[:preload_scope]
-            scope = scope_lambda.call(args, ctx)
+            scope = field.metadata[:preload_scope].call(args, ctx)
           end
 
-          preload(obj, field.metadata[:preload], scope_lambda, scope).then do
+          preload(obj, field.metadata[:preload], scope).then do
             old_resolver.call(obj, args, ctx)
           end
         end
@@ -24,11 +23,11 @@ module GraphQL
         end
       end
 
-      private def preload(record, associations, scope_lambda, scope)
+      private def preload(record, associations, scope)
         if associations.is_a?(String)
           raise TypeError, "Expected #{associations} to be a Symbol, not a String"
         elsif associations.is_a?(Symbol)
-          return preload_single_association(record, associations, scope_lambda, scope)
+          return preload_single_association(record, associations, scope)
         end
 
         promises = []
@@ -36,24 +35,24 @@ module GraphQL
         Array.wrap(associations).each do |association|
           case association
           when Symbol
-            promises << preload_single_association(record, association, scope_lambda, scope)
+            promises << preload_single_association(record, association, scope)
           when Array
             association.each do |sub_association|
-              promises << preload(record, sub_association, scope_lambda, scope)
+              promises << preload(record, sub_association, scope)
             end
           when Hash
             association.each do |sub_association, nested_association|
               promises << preload_single_association(record, sub_association,
-                scope_lambda, scope).then do
+                  scope).then do
                 associated_records = record.public_send(sub_association)
 
                 case associated_records
                 when ActiveRecord::Base
-                  preload(associated_records, nested_association, scope_lambda, scope)
+                  preload(associated_records, nested_association, scope)
                 else
                   Promise.all(
                     Array.wrap(associated_records).map do |associated_record|
-                      preload(associated_record, nested_association, scope_lambda, scope)
+                      preload(associated_record, nested_association, scope)
                     end
                   )
                 end
@@ -65,8 +64,19 @@ module GraphQL
         Promise.all(promises)
       end
 
-      private def preload_single_association(record, association, scope_lambda, scope)
-        loader = GraphQL::Preload::Loader.for(record.class, association, scope_lambda)
+      private def preload_single_association(record, association, scope)
+        # We would like to pass the `scope` (which is an
+        # `ActiveRecord::Relation`), directly into `Loader.for`, because that is
+        # what is needed for `Preloader.new`.  However, because the scope is
+        # created for each parent record, they are different objects and
+        # therefore would return different loaders, breaking batching.
+        # Therefore, we pass in `scope.to_sql`, which is the same for all the
+        # scopes and set the `scope` using an accessor.  So the actual scope
+        # object used will be the last one, which shouldn't make any difference,
+        # beacuse even though they are different objects, they are all
+        # equivalent.
+        loader = GraphQL::Preload::Loader.for(record.class, association,
+          scope.to_sql)
         loader.scope = scope
         loader.load(record)
       end

--- a/lib/graphql/preload/instrument.rb
+++ b/lib/graphql/preload/instrument.rb
@@ -9,7 +9,12 @@ module GraphQL
         new_resolver = ->(obj, args, ctx) do
           return old_resolver.call(obj, args, ctx) unless obj
 
-          preload(obj, field.metadata[:preload]).then do
+          if field.metadata[:preload_scope]
+            scope_lambda = field.metadata[:preload_scope]
+            scope = scope_lambda.call(args, ctx)
+          end
+
+          preload(obj, field.metadata[:preload], scope_lambda, scope).then do
             old_resolver.call(obj, args, ctx)
           end
         end
@@ -19,32 +24,36 @@ module GraphQL
         end
       end
 
-      private def preload(record, associations)
-        raise TypeError, "Expected #{associations} to be a Symbol, not a String" if associations.is_a?(String)
-        return preload_single_association(record, associations) if associations.is_a?(Symbol)
+      private def preload(record, associations, scope_lambda, scope)
+        if associations.is_a?(String)
+          raise TypeError, "Expected #{associations} to be a Symbol, not a String"
+        elsif associations.is_a?(Symbol)
+          return preload_single_association(record, associations, scope_lambda, scope)
+        end
 
         promises = []
 
         Array.wrap(associations).each do |association|
           case association
           when Symbol
-            promises << preload_single_association(record, association)
+            promises << preload_single_association(record, association, scope_lambda, scope)
           when Array
             association.each do |sub_association|
-              promises << preload(record, sub_association)
+              promises << preload(record, sub_association, scope_lambda, scope)
             end
           when Hash
             association.each do |sub_association, nested_association|
-              promises << preload_single_association(record, sub_association).then do
+              promises << preload_single_association(record, sub_association,
+                scope_lambda, scope).then do
                 associated_records = record.public_send(sub_association)
 
                 case associated_records
                 when ActiveRecord::Base
-                  preload(associated_records, nested_association)
+                  preload(associated_records, nested_association, scope_lambda, scope)
                 else
                   Promise.all(
                     Array.wrap(associated_records).map do |associated_record|
-                      preload(associated_record, nested_association)
+                      preload(associated_record, nested_association, scope_lambda, scope)
                     end
                   )
                 end
@@ -56,8 +65,10 @@ module GraphQL
         Promise.all(promises)
       end
 
-      private def preload_single_association(record, association)
-        GraphQL::Preload::Loader.for(record.class, association).load(record)
+      private def preload_single_association(record, association, scope_lambda, scope)
+        loader = GraphQL::Preload::Loader.for(record.class, association, scope_lambda)
+        loader.scope = scope
+        loader.load(record)
       end
     end
   end

--- a/lib/graphql/preload/instrument.rb
+++ b/lib/graphql/preload/instrument.rb
@@ -75,8 +75,9 @@ module GraphQL
         # object used will be the last one, which shouldn't make any difference,
         # beacuse even though they are different objects, they are all
         # equivalent.
+
         loader = GraphQL::Preload::Loader.for(record.class, association,
-          scope.to_sql)
+          scope&.to_sql)
         loader.scope = scope
         loader.load(record)
       end

--- a/lib/graphql/preload/instrument.rb
+++ b/lib/graphql/preload/instrument.rb
@@ -77,7 +77,7 @@ module GraphQL
         # equivalent.
 
         loader = GraphQL::Preload::Loader.for(record.class, association,
-          scope&.to_sql)
+          scope.try(:to_sql))
         loader.scope = scope
         loader.load(record)
       end

--- a/lib/graphql/preload/loader.rb
+++ b/lib/graphql/preload/loader.rb
@@ -35,11 +35,19 @@ module GraphQL
       end
 
       private def preload_association(records)
+        preload_scope = if scope&.klass ==
+                            model.reflect_on_association(association).klass
+                          scope
+                        else
+                          nil
+                        end
         if ((ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 1) ||
             ActiveRecord::VERSION::MAJOR > 4)
-          ActiveRecord::Associations::Preloader.new.preload(records, association, scope)
+          ActiveRecord::Associations::Preloader.new.preload(records, association,
+            preload_scope)
         else
-          ActiveRecord::Associations::Preloader.new(records, association, scope).run
+          ActiveRecord::Associations::Preloader.new(records, association,
+            preload_scope).run
         end
       end
 

--- a/lib/graphql/preload/loader.rb
+++ b/lib/graphql/preload/loader.rb
@@ -9,7 +9,7 @@ module GraphQL
         record.object_id
       end
 
-      def initialize(model, association, _scope_lambda)
+      def initialize(model, association, _scope_sql)
         @association = association
         @model = model
 

--- a/lib/graphql/preload/loader.rb
+++ b/lib/graphql/preload/loader.rb
@@ -35,12 +35,6 @@ module GraphQL
       end
 
       private def preload_association(records)
-        preload_scope = if scope&.klass ==
-                            model.reflect_on_association(association).klass
-                          scope
-                        else
-                          nil
-                        end
         if ((ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 1) ||
             ActiveRecord::VERSION::MAJOR > 4)
           ActiveRecord::Associations::Preloader.new.preload(records, association,
@@ -48,6 +42,14 @@ module GraphQL
         else
           ActiveRecord::Associations::Preloader.new(records, association,
             preload_scope).run
+        end
+      end
+
+      private def preload_scope
+        if scope.try(:klass) == model.reflect_on_association(association).klass
+          scope
+        else
+          nil
         end
       end
 


### PR DESCRIPTION
This allows a preload scope to be specified when preloading associations.  It's based of the technique described here: http://aserafin.pl/2017/09/12/preloading-associations-with-dynamic-condition-in-rails/

The problem we were running into was when we had an association that they wanted to filter like this:

``` graphql
{
  allClients(first: 5){
    first_name
    transactions(filter: { posted_at_gt: "2017-10-01"}) {
      amount
    } 
  } 
}
```

Without this we have two options: preload normally which will load all the transactions (potentially WAY too many) and then filter them afterwords, or run an N+1 query for each client that will load the transactions for that client with the appropriate where clause.  Neither are performant.

This patch will allow loading all of this with two SQL statements: one for the clients and one for the transactions.

I'm not sure about the implementation.  Specifically how the scope lambda is an initialization argument that isn't used and how the scope gets overwritten each time.  However due to the limitations of graphql-batch, this was the best I could come up with.  I'm happy to discuss why I did it the way I did, or better ideas if you have them.  

