### PR TITLE
Fixes preload_scope when association is polymorphic

### DIFF
--- a/lib/graphql/preload/loader.rb
+++ b/lib/graphql/preload/loader.rb
@@ -39,7 +39,10 @@ module GraphQL
       end
 
       private def preload_scope
-        scope if scope.try(:klass) == model.reflect_on_association(association).klass
+        return nil unless scope
+        reflection = model.reflect_on_association(association)
+        raise ArgumentError, 'Cannot specify preload_scope for polymorphic associations' if reflection.polymorphic?
+        scope if scope.try(:klass) == reflection.klass
       end
 
       private def validate_association


### PR DESCRIPTION
Presently, the `preload_scope` check fails because
`model.reflect_on_association(assocation).klass` will never be valid for
polymorphic associations (ActiveRecord uses a placeholder klass name that is replaced by the real one during the loading process).

This pull request fixes the issue by skipping `preload_scope` if the scope isn't set, and raises an ArgumentError if `preload_scope` is set *and* the association is polymorphic. This doesn't change any existing behavior, just fixes the bug.