### PR TITLE
Restore previous syntax for declaring preload with definition blocks

### DIFF
--- a/lib/graphql/preload.rb
+++ b/lib/graphql/preload.rb
@@ -17,14 +17,18 @@ module GraphQL
 
     module FieldMetadata
       def initialize(*args, preload: nil, preload_scope: nil, **kwargs, &block)
-        if preload
-          @preload ||= []
-          @preload.concat Array.wrap preload
-        end
-        if preload_scope
-          @preload_scope = preload_scope
-        end
         super(*args, **kwargs, &block)
+        self.preload(preload) if preload
+        self.preload_scope(preload_scope) if preload_scope
+      end
+
+      def preload(associations)
+        @preload ||= []
+        @preload.concat Array.wrap associations
+      end
+
+      def preload_scope(scope_proc)
+        @preload_scope = scope_proc
       end
 
       def to_graphql


### PR DESCRIPTION
Current examples in README.md are based on the syntax of graphql gem DSL before version 1.8.

After #11 was merged these examples aren't working anymore as currently, only modern syntax supported that use options hashes for DSL methods, like this:

```ruby
  field :quantity, Integer, null: true,
                            preload: :variations,
                            preload_scope: ->(*) { VARIATION_RELATION },
                            description: "Virtual field. Sum of all variations' quantities"
```

I personally like old-fashioned definition blocks more. Especially for long things like descriptions:

```rb
  field :quantity, Integer, null: true do
    preload :variations
    preload_scope ->(*) { VARIATION_RELATION }

    description "Virtual field. Sum of all variations' quantities"
  end
```

In this PR I'm restoring old syntax so both above examples can be used interchangeably and even can be mixed together.

See related discussion starting from https://github.com/ConsultingMD/graphql-preload/pull/11#issuecomment-404585759 

@RoryO, can you please take a look? If #14 will be merged first I will be glad to add specs for this syntax too.