### PR TITLE
Add support for old/new graphql syntax API

### DIFF
--- a/lib/graphql/preload.rb
+++ b/lib/graphql/preload.rb
@@ -2,6 +2,20 @@ require 'graphql'
 require 'graphql/batch'
 require 'promise.rb'
 
+GraphQL::Field.accepts_definitions(
+  preload: ->(type, *args) do
+    type.metadata[:preload] ||= []
+    type.metadata[:preload].concat(args)
+  end,
+  preload_scope: ->(type, arg) { type.metadata[:preload_scope] = arg }
+)
+
+GraphQL::Schema.accepts_definitions(
+  enable_preloading: ->(schema) do
+    schema.instrument(:field, GraphQL::Preload::Instrument.new)
+  end
+)
+
 module GraphQL
   # Provides a GraphQL::Field definition to preload ActiveRecord::Associations
   module Preload

--- a/lib/graphql/preload/instrument.rb
+++ b/lib/graphql/preload/instrument.rb
@@ -86,7 +86,7 @@ module GraphQL
       private def merged_metadata(field)
         type_class = field.metadata.fetch(:type_class, nil)
 
-        if type_class.nil?
+        if type_class.nil? || !type_class.respond_to?(:to_graphql)
           field.metadata
         else
           field.metadata.merge(type_class.to_graphql.metadata)

--- a/lib/graphql/preload/instrument.rb
+++ b/lib/graphql/preload/instrument.rb
@@ -13,7 +13,11 @@ module GraphQL
             scope = field.metadata[:preload_scope].call(args, ctx)
           end
 
-          preload(obj.object, field.metadata[:preload], scope).then do
+          is_graphql_object = obj.is_a?(GraphQL::Schema::Object)
+          respond_to_object = obj.respond_to?(:object)
+          record = is_graphql_object && respond_to_object ? obj.object : obj
+
+          preload(record, field.metadata[:preload], scope).then do
             old_resolver.call(obj, args, ctx)
           end
         end


### PR DESCRIPTION
This PR is adding support for Schema/Field.define old style API so people can migrate slowly to the new api while being able to update graphql-reload itself.

See #16