### PR TITLE
Fix preload metadata check

### DIFF
--- a/lib/graphql/preload/instrument.rb
+++ b/lib/graphql/preload/instrument.rb
@@ -3,7 +3,7 @@ module GraphQL
     # Provides an instrument for the GraphQL::Field :preload definition
     class Instrument
       def instrument(_type, field)
-        return field unless field.metadata.include?(:preload)
+        return field unless field.metadata[:preload]
 
         old_resolver = field.resolve_proc
         new_resolver = ->(obj, args, ctx) do


### PR DESCRIPTION
`FieldMetadata.to_graphql` always set preload metadata regardless of whether it is nil, therefore each metadata of field will has a `preload` key. Checking preload value is better option than  checking preload key.