### PR TITLE
Preloading decorated objects

### DIFF
--- a/lib/graphql/preload/instrument.rb
+++ b/lib/graphql/preload/instrument.rb
@@ -24,6 +24,7 @@ module GraphQL
       end
 
       private def preload(record, associations, scope)
+        record = record.to_model if record.respond_to?(:to_model)
         if associations.is_a?(String)
           raise TypeError, "Expected #{associations} to be a Symbol, not a String"
         elsif associations.is_a?(Symbol)


### PR DESCRIPTION
When a field returns decorated objects, it fails to preload data because the object passed to the preloading mechanism is not an ActiveRecord::Base (`Model must be an ActiveRecord::Base descendant`)

```ruby
field :users, [Types::User], null: false

def users
  User.all.each{ |user| UserDecorator.new(user) }
end

```

This PR allows decorators (or any wrappers) to implement `#to_model` method that will return an underlying model.


