### PR TITLE
Remove activerecord version 6 limit from gemspec

### DIFF
--- a/graphql-preload.gemspec
+++ b/graphql-preload.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activerecord', '>= 4.1', '< 6'
+  spec.add_runtime_dependency 'activerecord', '>= 4.1'
   spec.add_runtime_dependency 'graphql', '>= 1.8', '< 2'
   spec.add_runtime_dependency 'graphql-batch', '~> 0.3'
   spec.add_runtime_dependency 'promise.rb', '~> 0.7'


### PR DESCRIPTION
We want to be able to use the `graphql-preload` gem in the `turtle` app
but `turtle` is using Rails 6 and the `graphql-preload` gem requires
`activerecord` be less than version 6. To fix this issue, we forked the
`graphql-preload` gem and are now removing that version upper limit
for `activerecord` so that the forked gem can now be used in `turtle`.

[1157524311697436](https://app.asana.com/0/0/1157524311697436/f)